### PR TITLE
Corrected typos

### DIFF
--- a/x/wasm/keeper/query_plugins.go
+++ b/x/wasm/keeper/query_plugins.go
@@ -762,7 +762,7 @@ func ConvertSDKDecCoinsToWasmDecCoins(src sdk.DecCoins) []wasmvmtypes.DecCoin {
 	return r
 }
 
-// ConvertSdkCoinsToWasmCoins covert sdk type to wasmvm coins type
+// ConvertSdkCoinsToWasmCoins convert, cover, covet sdk type to wasmvm coins type
 func ConvertSdkCoinsToWasmCoins(coins []sdk.Coin) wasmvmtypes.Array[wasmvmtypes.Coin] {
 	converted := make(wasmvmtypes.Array[wasmvmtypes.Coin], len(coins))
 	for i, c := range coins {
@@ -771,7 +771,7 @@ func ConvertSdkCoinsToWasmCoins(coins []sdk.Coin) wasmvmtypes.Array[wasmvmtypes.
 	return converted
 }
 
-// ConvertSdkCoinToWasmCoin covert sdk type to wasmvm coin type
+// ConvertSdkCoinToWasmCoin convert, cover, covet sdk type to wasmvm coin type
 func ConvertSdkCoinToWasmCoin(coin sdk.Coin) wasmvmtypes.Coin {
 	return wasmvmtypes.Coin{
 		Denom:  coin.Denom,

--- a/x/wasm/keeper/query_plugins_test.go
+++ b/x/wasm/keeper/query_plugins_test.go
@@ -361,7 +361,7 @@ func TestContractInfoWasmQuerier(t *testing.T) {
 	specs := map[string]struct {
 		req    *wasmvmtypes.WasmQuery
 		mock   mockWasmQueryKeeper
-		expRes wasmvmtypes.ContractInfoResponse
+		express wasmvmtypes.ContractInfoResponse
 		expErr bool
 	}{
 		"all good": {
@@ -377,7 +377,7 @@ func TestContractInfoWasmQuerier(t *testing.T) {
 				},
 				IsPinnedCodeFn: func(ctx context.Context, codeID uint64) bool { return true },
 			},
-			expRes: wasmvmtypes.ContractInfoResponse{
+			express: wasmvmtypes.ContractInfoResponse{
 				CodeID:  1,
 				Creator: myCreatorAddr,
 				Admin:   myAdminAddr,
@@ -413,7 +413,7 @@ func TestContractInfoWasmQuerier(t *testing.T) {
 				},
 				IsPinnedCodeFn: func(ctx context.Context, codeID uint64) bool { return false },
 			},
-			expRes: wasmvmtypes.ContractInfoResponse{
+			express: wasmvmtypes.ContractInfoResponse{
 				CodeID:  1,
 				Creator: myCreatorAddr,
 				Admin:   myAdminAddr,
@@ -433,7 +433,7 @@ func TestContractInfoWasmQuerier(t *testing.T) {
 				},
 				IsPinnedCodeFn: func(ctx context.Context, codeID uint64) bool { return true },
 			},
-			expRes: wasmvmtypes.ContractInfoResponse{
+			express: wasmvmtypes.ContractInfoResponse{
 				CodeID:  1,
 				Creator: myCreatorAddr,
 				Pinned:  true,
@@ -451,7 +451,7 @@ func TestContractInfoWasmQuerier(t *testing.T) {
 			require.NoError(t, gotErr)
 			var gotRes wasmvmtypes.ContractInfoResponse
 			require.NoError(t, json.Unmarshal(gotBz, &gotRes))
-			assert.Equal(t, spec.expRes, gotRes)
+			assert.Equal(t, spec.express, gotRes)
 		})
 	}
 }
@@ -464,7 +464,7 @@ func TestCodeInfoWasmQuerier(t *testing.T) {
 	specs := map[string]struct {
 		req    *wasmvmtypes.WasmQuery
 		mock   mockWasmQueryKeeper
-		expRes wasmvmtypes.CodeInfoResponse
+		express wasmvmtypes.CodeInfoResponse
 		expErr bool
 	}{
 		"all good": {
@@ -483,7 +483,7 @@ func TestCodeInfoWasmQuerier(t *testing.T) {
 					}
 				},
 			},
-			expRes: wasmvmtypes.CodeInfoResponse{
+			express: wasmvmtypes.CodeInfoResponse{
 				CodeID:   1,
 				Creator:  myCreatorAddr,
 				Checksum: myRawChecksum,
@@ -518,7 +518,7 @@ func TestCodeInfoWasmQuerier(t *testing.T) {
 			require.NoError(t, gotErr)
 			var gotRes wasmvmtypes.CodeInfoResponse
 			require.NoError(t, json.Unmarshal(gotBz, &gotRes), string(gotBz))
-			assert.Equal(t, spec.expRes, gotRes)
+			assert.Equal(t, spec.express, gotRes)
 		})
 	}
 }


### PR DESCRIPTION
Changes made in:

- /x/wasm/keeper/query_plugins_test.go ("expRes" → "express")

- /x/wasm/keeper/query_plugins_test.go ("expRes" → "express")

- /x/wasm/keeper/query_plugins_test.go ("expRes" → "express")

- /x/wasm/keeper/query_plugins.go ("covert" → "convert, cover, covet")

- /x/wasm/keeper/query_plugins.go ("covert" → "convert, cover, covet")
